### PR TITLE
トップページから詳細ページへ

### DIFF
--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -134,8 +134,9 @@
         .pickup__box__lists
           - @items.each do |item|
             .pickup__box__lists__list
-              = link_to "/" do
-                .list__img = image_tag item.images.first.image_url
+              = link_to item_path(id: item.id) do
+                .list__img 
+                = image_tag item.images.first.image_url
                 .list__body
                   %h3.list__body__name
                     = item.name


### PR DESCRIPTION
#what
トップページから詳細ページへ
#why
トップページにある出品された商品をクリックするとその商品詳細ページに飛べるようにするため