### PR TITLE
ノーアイコン実装

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -176,7 +176,10 @@
                       %strong
                         = link_to comment.user.nickname, all_items_user_path(id: comment.user.id)
                         = link_to all_items_user_path(id: comment.user.id) do
-                          = image_tag comment.user.avter_url
+                          - if comment.user.avter.present?
+                            = image_tag comment.user.avter_url
+                          - else
+                            = image_tag 'icon/member_photo_noimage_thumb.png'
                     - if comment.user.id == @user.id
                       .user-seller
                         = link_to all_items_user_path(id: @user.id) do


### PR DESCRIPTION
#what
コメント欄、アイコン未設定のユーザーのアイコンを設定
#why
アイコン未設定のユーザーがコメントした時のページがなかったため